### PR TITLE
Maintaining State On Actions.

### DIFF
--- a/src/components/chat/index.js
+++ b/src/components/chat/index.js
@@ -254,43 +254,21 @@ export class Chat extends Component {
   }
 
   _validateDatasetExists(datasetName) {
-    if (datasetName == "Everything") { return true; }
+    const datasets = this._getAllDatasets();
 
-    // maybe there's a better way to do this but I haven't found it in the kepler docs, feel free to redo this
-    var i = 0;
-    var datasets = this._getAllDatasets();
-
-    while (i < datasets.length) {
-      if (datasets[i].id == datasetName) { return true; }
-      i++;
-    }
-
-    return false;
+    if (datasetName == "Everything") return true;
+    return datasets.find(dataset => dataset.id == datasetName) ? true : false;
   }
 
   _validateField(datasetName, field) {
-    // assume dataset exists
-    var datasets = this._getAllDatasets();
-    var dataset = null;
-    var i = 0;
+    const datasets = this._getAllDatasets();
+    const dataset = datasets.find(dataset => dataset.id == datasetName);
 
-    while (i < datasets.length && dataset == null) {
-      if (datasets[i].id == datasetName) {
-        dataset = datasets[i]
-      }
-
-      i++;
+    if (dataset) {
+      return dataset.fields.find(f => f.name == field) ? true : false;
+    } else {
+      return false;
     }
-
-    // found the dataset
-    i = 0;
-    while (i < dataset.fields.length) {
-      if (dataset.fields[i].name == field) { return true; }
-      i++;
-    }
-
-    // if not already found and returned
-    return false;
   }
 
   _renderResponses() {

--- a/src/components/chat/index.js
+++ b/src/components/chat/index.js
@@ -85,8 +85,8 @@ export class Chat extends Component {
       responses: [...this.state.responses, "..."],
     });
     const res = await sendMessage(this.state.inputText);
-    this.setState({ responses: this.state.responses.slice(0, -1) });
 
+    this._removeLastMessage();
     this._addMessageToState(res.text ? res.text : "no response...")
 
     switch (res.action) {
@@ -112,6 +112,12 @@ export class Chat extends Component {
         break;
     }
   };
+
+  // Right now, this is used essentially every time before we add a new message
+  // however, i feel like including this in the add message code is asking for confusion down the line
+  _removeLastMessage() {
+    this.setState({ responses: this.state.responses.slice(0, -1) });
+  }
 
   _addMessageToState(message) {
     const responses = this.state.responses.concat(message);
@@ -164,9 +170,11 @@ export class Chat extends Component {
             break;
         }
       } else {
+        this._removeLastMessage();
         this._addMessageToState("That doesn't look like a valid field on that dataset.");
       }
     } else {
+      this._removeLastMessage();
       this._addMessageToState("Sorry, we can't find that dataset.");
     }
   }
@@ -209,6 +217,7 @@ export class Chat extends Component {
         });
       }
     } else {
+      this._removeLastMessage();
       this._addMessageToState("Sorry, we can't find that dataset.");
     }
   }

--- a/src/components/chat/index.js
+++ b/src/components/chat/index.js
@@ -72,7 +72,6 @@ export class Chat extends Component {
   state = {
     inputText: "",
     responses: [],
-    nextDatasetId: 0,
   };
 
   constructor(props) {
@@ -101,7 +100,8 @@ export class Chat extends Component {
         this._addFilter(
           res.variables.filter_field,
           res.variables.sys_number,
-          res.variables.filter_comparison
+          res.variables.filter_comparison,
+          res.variables.dataset_name
         );
         break;
 
@@ -110,7 +110,7 @@ export class Chat extends Component {
         break;
 
       case this.ActionKeys.Clear:
-        this._clearDatasets();
+        this._clearDataset(res.variables.dataset_name);
         break;
     }
   };
@@ -186,13 +186,8 @@ export class Chat extends Component {
     return fieldMap[field];
   }
 
-  _clearDatasets() {
-    var i;
-    for (i = 0; i < this.state.nextDatasetId; i++) {
-      this.props.removeDataset("" + i);
-    }
-
-    this.setState({ nextDatasetId: 0 });
+  _clearDataset(dataset) {
+    this.props.removeDataset(dataset);
   }
 
   async _loadDataset(datasetName) {
@@ -203,14 +198,12 @@ export class Chat extends Component {
         {
           info: {
             label: datasetName,
-            id: "" + this.state.nextDatasetId,
+            id: datasetName,
           },
           data: processCsvData(data),
         },
       ],
     });
-
-    await this.setState({ nextDatasetId: this.state.nextDatasetId + 1 });
   }
 
   _resolveDataset(datasetName) {

--- a/src/components/chat/index.js
+++ b/src/components/chat/index.js
@@ -187,7 +187,17 @@ export class Chat extends Component {
   }
 
   _clearDataset(dataset) {
-    this.props.removeDataset(dataset);
+    if (dataset != "Everything") {
+      this.props.removeDataset(dataset);
+    } else {
+      // Everything
+      const { removeDataset, keplerGl } = this.props;
+      const { visState } = keplerGl.foo
+
+      Object.values(visState.datasets).forEach(function (datasetObj) {
+        removeDataset(datasetObj.id);
+      });
+    }
   }
 
   async _loadDataset(datasetName) {


### PR DESCRIPTION
This PR adds three main enhancements:

- Users are now required to specify dataset for clearing and adding filters. ('Everything is a valid dataset for clearing).
- We now validate user input, to ensure that the proper dataset to clear or add a filter is present.
- Users see relevant feedback when they try to add a filter or clear a dataset which is not present.

There is a small API side change that is correlated with this PR, which can be found here: https://github.com/speaq-ai/api/pull/5

This closes this issue: https://github.com/speaq-ai/react-ui/issues/20