### PR TITLE
UI Refactor

### DIFF
--- a/src/components/chat/action-processor.js
+++ b/src/components/chat/action-processor.js
@@ -1,0 +1,287 @@
+import sacramentoRealEstate from "../../data/SacramentoRealEstate";
+import earthquake from "../../data/Earthquake";
+import { processCsvData } from "kepler.gl/processors";
+import {
+	addFilter,
+	setFilter,
+	addDataToMap,
+	togglePerspective,
+	layerTypeChange,
+	updateMap,
+	removeDataset,
+} from "kepler.gl/actions";
+
+export default class ActionProcessor {
+	constructor(keplerGl, dispatch) {
+		this._keplerGl = keplerGl;
+		this._dispatch = dispatch;
+	}
+
+	static ACTION_KEYS = {
+		ADD_FILTER: "AddFilter",
+		LOAD_DATASET: "LoadData",
+		CLEAR: "Clear",
+		CHANGE_VIEW_MODE: "ChangeViewMode",
+		VIEW_ACTION: "ViewAction",
+		GOTO_ACTION: "GotoAction",
+	};
+
+	static RESPONSES = {
+		INVALID_DATASET: "Sorry, we can't find that dataset.",
+		INVALID_FIELD: dataset =>
+			`That doesn't look like a valid field on the ${dataset} dataset.`,
+		SUCCESS_FILTER: "Great, let's get that filter going.",
+	};
+
+	// static resolution methods
+	static _resolveDataset(datasetName) {
+		var datasetMap = {
+			Earthquake: earthquake,
+			"Sacramento real estate": sacramentoRealEstate,
+		};
+
+		return datasetMap[datasetName];
+	}
+	static _resolveField(field) {
+		var fieldMap = {
+			price: "price",
+			beds: "beds",
+			baths: "baths",
+			year: "year",
+			magnitude: "magnitude",
+			depth: "depth",
+		};
+		return fieldMap[field];
+	}
+
+	updateKepler(keplerGl) {
+		this._keplerGl = keplerGl;
+	}
+
+	// validation helper methods
+	_getAllDatasets() {
+		const { visState } = this._keplerGl.foo;
+		return Object.values(visState.datasets);
+	}
+
+	_validateDatasetExists(datasetName) {
+		const datasets = this._getAllDatasets();
+		if (datasetName == "Everything") return true;
+		return datasets.find(dataset => dataset.id == datasetName) ? true : false;
+	}
+
+	_validateField(datasetName, field) {
+		const datasets = this._getAllDatasets();
+		const dataset = datasets.find(dataset => dataset.id == datasetName);
+
+		if (dataset) {
+			return dataset.fields.find(f => f.name == field) ? true : false;
+		} else {
+			return false;
+		}
+	}
+
+	process = async res => {
+		const { ACTION_KEYS } = ActionProcessor;
+		switch (res.action) {
+			case ACTION_KEYS.ADD_FILTER:
+				return await this._addFilter(
+					res.variables.filter_field,
+					res.variables.sys_number,
+					res.variables.filter_comparison,
+					res.variables.dataset_name
+				);
+
+			case ACTION_KEYS.LOAD_DATASET:
+				return this._loadDataset(res.variables.dataset_name);
+
+			case ACTION_KEYS.CLEAR:
+				return this._clearDataset(res.variables.dataset_name);
+
+			case ACTION_KEYS.CHANGE_VIEW_MODE:
+				return this._changeViewMode(res.variables.view_mode);
+
+			case ACTION_KEYS.VIEW_ACTION:
+				return this._executeViewAction(res.variables.view_action);
+
+			case ACTION_KEYS.GOTO_ACTION:
+				return this._moveMap(
+					res.variables.location[0],
+					res.variables.location[1]
+				);
+			default:
+				return [];
+		}
+	};
+
+	/*
+	 * ONLY WORKS FOR NUMERICS CURRENTLY
+	 * Taking actions below.
+	 * add filter takes the following arguments:
+	 * field: filed name to create the filter for
+	 * value: the value to use in the filter comparison
+	 * comparator: one of {"gt", "lt", "eq"}
+	 * dataset: TODO: lookup id if provided, else use
+	 * most recently loaded dataset ID.
+	 */
+	async _addFilter(field, value, comparator, dataset) {
+		if (dataset == "Everything") {
+			const responses = [];
+			this._getAllDatasets().forEach(async datasetObj => {
+				responses.push(
+					await this._addFilter(field, value, comparator, datasetObj.id)
+				);
+			});
+			return responses;
+		}
+
+		// validation
+		if (!this._validateDatasetExists(dataset)) {
+			return [ActionProcessor.RESPONSES.INVALID_DATASET];
+		} else if (!this._validateField(dataset, field)) {
+			return [ActionProcessor.RESPONSES.INVALID_FIELD];
+		}
+
+		const { visState } = this._keplerGl.foo;
+		const datasetId = dataset || Object.values(visState.datasets)[0].id;
+		const filterId = visState.filters.length;
+
+		await this._dispatch(addFilter(datasetId));
+		await this._dispatch(
+			setFilter(filterId, "name", ActionProcessor._resolveField(field))
+		);
+
+		switch (comparator) {
+			case "greater than":
+				await this._setGtFilter(filterId, value);
+				break;
+			case "less than":
+				await this._setLtFilter(filterId, value);
+				break;
+			case "equal":
+				await this._setEqFilter(filterId, value);
+				break;
+			default:
+				break;
+		}
+		return [ActionProcessor.RESPONSES.SUCCESS_FILTER];
+	}
+
+	async _setGtFilter(filterId, value) {
+		this._dispatch(
+			setFilter(filterId, "value", [value, Number.MAX_SAFE_INTEGER])
+		);
+	}
+
+	async _setLtFilter(filterId, value) {
+		this._dispatch(
+			setFilter(filterId, "value", [Number.MIN_SAFE_INTEGER, value])
+		);
+	}
+
+	async _setEqFilter(filterId, value) {
+		this._dispatch(setFilter(filterId, "value", [value, value]));
+	}
+
+	_clearDataset(dataset) {
+		if (!this._validateDatasetExists(dataset)) {
+			return [ActionProcessor.RESPONSES.INVALID_DATASET];
+		}
+		if (dataset != "Everything") {
+			this._dispatch(removeDataset(dataset));
+		} else {
+			// Everything
+			this._getAllDatasets().forEach(datasetObj => {
+				this._dispatch(removeDataset(datasetObj.id));
+			});
+		}
+		return [];
+	}
+
+	_loadDataset(datasetName) {
+		const data = ActionProcessor._resolveDataset(datasetName);
+		this._dispatch(
+			addDataToMap({
+				datasets: [
+					{
+						info: {
+							label: datasetName,
+							id: datasetName,
+						},
+						data: processCsvData(data),
+					},
+				],
+			})
+		);
+		return [];
+	}
+
+	_changeViewMode(viewMode) {
+		const layers = this._keplerGl.foo.visState.layers;
+
+		switch (viewMode) {
+			case 3: // Watson strips the D for some reason
+			case "3D":
+				this._dispatch(togglePerspective());
+				break;
+			case "cluster":
+				this._dispatch(layerTypeChange(layers[0], "cluster"));
+				break;
+			case "point":
+				this._dispatch(layerTypeChange(layers[0], "point"));
+				break;
+			case "grid":
+				this._dispatch(layerTypeChange(layers[0], "grid"));
+				break;
+			case "hexbin":
+				this._dispatch(layerTypeChange(layers[0], "hexagon"));
+				break;
+			case "heatmap":
+				this._dispatch(layerTypeChange(layers[0], "heatmap"));
+				break;
+		}
+		return [];
+	}
+
+	_executeViewAction(viewAction) {
+		const mapState = this._keplerGl.foo.mapState;
+
+		switch (viewAction) {
+			case "in":
+				this._dispatch(updateMap({ zoom: mapState.zoom * 1.1 }));
+				break;
+			case "out":
+				this._dispatch(updateMap({ zoom: mapState.zoom * 0.9 }));
+				break;
+			case "up":
+				this._dispatch(
+					updateMap({ latitude: mapState.latitude + 1 / mapState.zoom })
+				);
+				break;
+			case "down":
+				this._dispatch(
+					updateMap({ latitude: mapState.latitude - 1 / mapState.zoom })
+				);
+				break;
+			case "right":
+				this._dispatch(
+					updateMap({ longitude: mapState.longitude + 1 / mapState.zoom })
+				);
+				break;
+			case "left":
+				this._dispatch(
+					updateMap({ longitude: mapState.longitude - 1 / mapState.zoom })
+				);
+				break;
+			case "enhance":
+				this._dispatch(updateMap({ zoom: mapState.zoom * 1.5 }));
+				break;
+		}
+		return [];
+	}
+
+	_moveMap(lat, long) {
+		this._dispatch(updateMap({ latitude: lat, longitude: long }));
+		return [];
+	}
+}

--- a/src/components/chat/index.js
+++ b/src/components/chat/index.js
@@ -2,6 +2,7 @@ import React, { Component } from "react";
 import styled from "styled-components";
 import { sendMessage } from "@/utils/speaq-api";
 import { processCsvData } from "kepler.gl/processors";
+import { setFilter, addDataToMap, togglePerspective, layerTypeChange, updateMap, removeDataset } from "kepler.gl/actions";
 import sacramentoRealEstate from "../../data/SacramentoRealEstate";
 import earthquake from "../../data/Earthquake";
 import FileSaver from "file-saver";
@@ -272,18 +273,15 @@ export class Chat extends Component {
   }
 
   async _setGtFilter(filterId, value) {
-    const { setFilter } = this.props;
-    await setFilter(filterId, "value", [value, Number.MAX_SAFE_INTEGER]);
+    this.props.dispatch(setFilter(filterId, "value", [value, Number.MAX_SAFE_INTEGER]));
   }
 
   async _setLtFilter(filterId, value) {
-    const { setFilter } = this.props;
-    await setFilter(filterId, "value", [Number.MIN_SAFE_INTEGER, value]);
+    this.props.dispatch(setFilter(filterId, "value", [Number.MIN_SAFE_INTEGER, value]));
   }
 
   async _setEqFilter(filterId, value) {
-    const { setFilter } = this.props;
-    await setFilter(filterId, "value", [value, value]);
+    this.props.dispatch(setFilter(filterId, "value", [value, value]));
   }
 
   _resolveField(field) {
@@ -301,11 +299,11 @@ export class Chat extends Component {
   _clearDataset(dataset) {
     if (this._validateDatasetExists(dataset)) {
       if (dataset != "Everything") {
-        this.props.removeDataset(dataset);
+        this.props.dispatch(removeDataset(dataset));
       } else {
         // Everything
         this._getAllDatasets().forEach(datasetObj => {
-          this.props.removeDataset(datasetObj.id);
+          this.props.dispatch(removeDataset(datasetObj.id));
         });
       }
     } else {
@@ -317,7 +315,7 @@ export class Chat extends Component {
   async _loadDataset(datasetName) {
     var data = this._resolveDataset(datasetName);
 
-    await this.props.addDataToMap({
+    this.props.dispatch(addDataToMap({
       datasets: [
         {
           info: {
@@ -327,7 +325,7 @@ export class Chat extends Component {
           data: processCsvData(data),
         },
       ],
-    });
+    }));
   }
 
   _resolveDataset(datasetName) {
@@ -341,7 +339,7 @@ export class Chat extends Component {
 
   // return as an array
   _getAllDatasets() {
-    const { removeDataset, keplerGl } = this.props;
+    const { keplerGl } = this.props;
     const { visState } = keplerGl.foo;
     return Object.values(visState.datasets);
   }
@@ -370,22 +368,22 @@ export class Chat extends Component {
     switch (viewMode) {
       case 3: // Watson strips the D for some reason
       case "3D":
-        await this.props.togglePerspective();
+        await this.props.dispatch(togglePerspective());
         break;
       case "cluster":
-        await this.props.layerTypeChange(layers[0], "cluster");
+        await this.props.dispatch(layerTypeChange(layers[0], "cluster"));
         break;
       case "point":
-        await this.props.layerTypeChange(layers[0], "point");
+        await this.props.dispatch(layerTypeChange(layers[0], "point"));
         break;
       case "grid":
-        await this.props.layerTypeChange(layers[0], "grid");
+        await this.props.dispatch(layerTypeChange(layers[0], "grid"));
         break;
       case "hexbin":
-        await this.props.layerTypeChange(layers[0], "hexagon");
+        await this.props.dispatch(layerTypeChange(layers[0], "hexagon"));
         break;
       case "heatmap":
-        await this.props.layerTypeChange(layers[0], "heatmap");
+        await this.props.dispatch(layerTypeChange(layers[0], "heatmap"));
         break;
     }
   }
@@ -395,31 +393,31 @@ export class Chat extends Component {
 
     switch (viewAction) {
       case "in":
-        await this.props.updateMap({ zoom: mapState.zoom * 1.1 });
+        await this.props.dispatch(updateMap({ zoom: mapState.zoom * 1.1 }));
         break;
       case "out":
-        await this.props.updateMap({ zoom: mapState.zoom * 0.9 });
+        await this.props.dispatch(updateMap({ zoom: mapState.zoom * 0.9 }));
         break;
       case "up":
-        await this.props.updateMap({ latitude: mapState.latitude + 1 / mapState.zoom });
+        await this.props.dispatch(updateMap({ latitude: mapState.latitude + 1 / mapState.zoom }));
         break;
       case "down":
-        await this.props.updateMap({ latitude: mapState.latitude - 1 / mapState.zoom });
+        await this.props.dispatch(updateMap({ latitude: mapState.latitude - 1 / mapState.zoom }));
         break;
       case "right":
-        await this.props.updateMap({ longitude: mapState.longitude + 1 / mapState.zoom });
+        await this.props.dispatch(updateMap({ longitude: mapState.longitude + 1 / mapState.zoom }));
         break;
       case "left":
-        await this.props.updateMap({ longitude: mapState.longitude - 1 / mapState.zoom });
+        await this.props.dispatch(updateMap({ longitude: mapState.longitude - 1 / mapState.zoom }));
         break;
       case "enhance":
-        await this.props.updateMap({ zoom: mapState.zoom * 1.5 });
+        await this.props.dispatch(updateMap({ zoom: mapState.zoom * 1.5 }));
         break;
     }
   }
 
   _moveMap(lat, long) {
-    this.props.updateMap({latitude: lat, longitude: long});
+    this.props.dispatch(updateMap({latitude: lat, longitude: long}));
   }
 
   _renderResponses() {

--- a/src/components/common/floating-button.js
+++ b/src/components/common/floating-button.js
@@ -1,5 +1,6 @@
 import React, { Component } from "react";
 import styled from "styled-components";
+import * as Icon from "react-feather";
 
 const Button = styled.button`
 	border-radius: 100%;
@@ -9,8 +10,8 @@ const Button = styled.button`
 	font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen,
 		Ubuntu, Cantarell, "Open Sans", "Helvetica Neue", sans-serif;
 	display: block;
-	width: ${props => props.size || "40px"}
-	height: ${props => props.size || "40px"}
+	width: ${props => props.size || "36px"}
+	height: ${props => props.size || "36px"}
 	&:hover {
 		cursor: pointer;
 	}
@@ -21,11 +22,18 @@ const Button = styled.button`
 
 export default class FloatingButton extends Component {
 	render() {
-		const { text, children, ...props } = this.props;
+		const { text, children, activeIcon, icon, active, ...props } = this.props;
+		const iconSize = 16;
+		const DefaultIcon = Icon[icon];
+		const ActiveIcon = Icon[activeIcon];
 		return (
 			<Button {...props}>
 				{text}
-				{children}
+				{active && activeIcon ? (
+					<ActiveIcon size={iconSize} color="#fff" />
+				) : (
+					<DefaultIcon size={iconSize} color="#fff" />
+				)}
 			</Button>
 		);
 	}

--- a/src/components/login/private-route.js
+++ b/src/components/login/private-route.js
@@ -1,16 +1,52 @@
-import React, { Component } from "react";
+import React, { Component, Fragment } from "react";
 import { Route, Redirect } from "react-router-dom";
+import styled from "styled-components";
+import { LogOut } from "react-feather";
+
+const NavContainer = styled.div`
+	display: flex;
+	justify-content: space-between;
+	align-items: center;
+	background-color: #2b4059;
+	padding: 10px;
+	box-shadow: 0 6px 12px 0 rgba(0, 0, 0, 0.16);
+`;
+
+const Logo = styled.div`
+	background-color: #15a5fa;
+	border-radius: 100px;
+	background-repeat: no-repeat;
+	background-position: center;
+	background-size: contain;
+	color: #fff;
+	font-size: 18px;
+	font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen,
+		Ubuntu, Cantarell, "Open Sans", "Helvetica Neue", sans-serif;
+	padding: 3px 10px;
+`;
 
 export default class PrivateRoute extends Component {
 	render() {
-		const { component: Component, path, authenticated, ...rest } = this.props;
+		const {
+			component: Component,
+			path,
+			logout,
+			authenticated,
+			...rest
+		} = this.props;
 		return (
 			<Route
 				{...rest}
 				path={path}
 				render={props =>
 					authenticated ? (
-						<Component {...props} />
+						<Fragment>
+							<NavContainer>
+								<Logo>speaqAI</Logo>
+								<LogOut color="white" size="20" onClick={logout} />
+							</NavContainer>
+							<Component {...props} />
+						</Fragment>
 					) : (
 						<Redirect
 							to={{ pathname: "/login", state: { from: props.location } }}

--- a/src/components/visualizer/index.js
+++ b/src/components/visualizer/index.js
@@ -1,51 +1,16 @@
 import React, { Component, Fragment } from "react";
-import { connect } from "react-redux";
 import KeplerGl from "kepler.gl";
 import { toggleSidePanel } from "kepler.gl/actions";
-import { processCsvData } from "kepler.gl/processors";
 import store from "@/ducks";
-import { sendMessage } from "@/utils/speaq-api";
 import styled from "styled-components";
 import { Chat } from "@/components/chat";
 import { AutoSizer } from "react-virtualized";
 import FloatingButton from "@/components/common/floating-button";
 import { AudioRecorder, blobToBase64 } from "@/utils/audio";
-import {
-	LogOut,
-	Mic,
-	Square,
-	Volume2,
-	VolumeX,
-	ArrowLeft,
-	MessageSquare,
-} from "react-feather";
 
 const MainContainer = styled.div`
 	display: flex;
-
 	height: calc(100vh - 50px);
-`;
-
-const NavContainer = styled.div`
-	display: flex;
-	justify-content: space-between;
-	align-items: center;
-	background-color: #2b4059;
-	padding: 10px;
-	box-shadow: 0 6px 12px 0 rgba(0, 0, 0, 0.16);
-`;
-
-const Logo = styled.div`
-	background-color: #15a5fa;
-	border-radius: 100px;
-	background-repeat: no-repeat;
-	background-position: center;
-	background-size: contain;
-	color: #fff;
-	font-size: 18px;
-	font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen,
-		Ubuntu, Cantarell, "Open Sans", "Helvetica Neue", sans-serif;
-	padding: 3px 10px;
 `;
 
 const MapContainer = styled.div`
@@ -61,24 +26,6 @@ const ChatContainer = styled.div`
 	transition: 0.35s all ease;
 	overflow: hidden;
 	box-shadow: 0 6px 12px 0 rgba(0, 0, 0, 0.16);
-`;
-
-const LogoutButton = styled.a`
-	grid-column: 12 / 13;
-	align-self: center;
-	justify-self: center;
-	color: white;
-	font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen,
-		Ubuntu, Cantarell, "Open Sans", "Helvetica Neue", sans-serif;
-	padding: 0.25em 1em;
-	margin: 0.5em;
-	background-color: #ff4136;
-	border-radius: 4px;
-	border: 2px solid #ff4136;
-
-	&:hover {
-		cursor: pointer;
-	}
 `;
 
 const ButtonContainer = styled.div`
@@ -106,7 +53,7 @@ export default class Visualizer extends Component {
 	};
 
 	componentDidMount() {
-		this.props.dispatch(toggleSidePanel())
+		this.props.dispatch(toggleSidePanel());
 	}
 
 	_handleAudioRecording = async () => {
@@ -125,6 +72,10 @@ export default class Visualizer extends Component {
 		this.setState({ inputSpeech: null });
 	};
 
+	_toggle = key => this.setState({ [key]: !this.state[key] });
+	_toggleOutputFormat = e => this._toggle("outputAsSpeech");
+	_toggleChatPanel = e => this._toggle("chatPanelOpen");
+
 	render() {
 		const mapboxAccessToken = process.env.MAPBOX_ACCESS_TOKEN;
 		const { logout } = this.props;
@@ -136,14 +87,8 @@ export default class Visualizer extends Component {
 			outputAsSpeech,
 			isRecording,
 		} = this.state;
-		const iconSize = 16;
-		const buttonSize = 36;
 		return (
 			<div>
-				<NavContainer>
-					<Logo>speaqAI</Logo>
-					<LogOut color="white" size="20" onClick={logout} />
-				</NavContainer>
 				<MainContainer>
 					<ChatContainer open={chatPanelOpen}>
 						<Chat
@@ -160,46 +105,27 @@ export default class Visualizer extends Component {
 								<Fragment>
 									<ButtonContainer>
 										<FloatingButton
-											size={buttonSize}
-											onClick={e =>
-												this.setState({ chatPanelOpen: !chatPanelOpen })
-											}
-											backgroundColor="#6A7485"
-										>
-											{chatPanelOpen ? (
-												<ArrowLeft color="white" size={iconSize} />
-											) : (
-												<MessageSquare color="white" size={iconSize} />
-											)}
-										</FloatingButton>
+											onClick={this._toggleChatPanel}
+											active={chatPanelOpen}
+											icon="MessageSquare"
+											activeIcon="ArrowLeft"
+										/>
 
 										<FloatingButton
 											backgroundColor={!outputAsSpeech ? "#6A7485" : "#F27E64"}
-											size={buttonSize}
-											onClick={e =>
-												this.setState({
-													outputAsSpeech: !outputAsSpeech,
-												})
-											}
-										>
-											{!outputAsSpeech ? (
-												<VolumeX color="white" size={iconSize} />
-											) : (
-												<Volume2 color="white" size={iconSize} />
-											)}
-										</FloatingButton>
+											onClick={this._toggleOutputFormat}
+											active={outputAsSpeech}
+											icon="VolumeX"
+											activeIcon="Volume2"
+										/>
 
 										<FloatingButton
 											backgroundColor={isRecording ? "#F27E64" : "#6A7485"}
-											size={buttonSize}
 											onClick={this._handleAudioRecording}
-										>
-											{isRecording ? (
-												<Square color="white" size={iconSize} />
-											) : (
-												<Mic color="white" size={iconSize} />
-											)}
-										</FloatingButton>
+											active={isRecording}
+											icon="Mic"
+											activeIcon="Square"
+										/>
 									</ButtonContainer>
 									<KeplerGl
 										id="foo"

--- a/src/components/visualizer/index.js
+++ b/src/components/visualizer/index.js
@@ -1,7 +1,7 @@
 import React, { Component, Fragment } from "react";
 import { connect } from "react-redux";
 import KeplerGl from "kepler.gl";
-import { addDataToMap } from "kepler.gl/actions";
+import { toggleSidePanel } from "kepler.gl/actions";
 import { processCsvData } from "kepler.gl/processors";
 import store from "@/ducks";
 import { sendMessage } from "@/utils/speaq-api";
@@ -106,8 +106,7 @@ export default class Visualizer extends Component {
 	};
 
 	componentDidMount() {
-		const { toggleSidePanel } = this.props;
-		toggleSidePanel();
+		this.props.dispatch(toggleSidePanel())
 	}
 
 	_handleAudioRecording = async () => {

--- a/src/containers/app.js
+++ b/src/containers/app.js
@@ -11,7 +11,7 @@ class App extends Component {
 		this.props.checkSession();
 	}
 	render() {
-		const { authenticated } = this.props;
+		const { authenticated, logout } = this.props;
 		return (
 			<div>
 				{authenticated === null ? (
@@ -21,6 +21,7 @@ class App extends Component {
 						<Route path="/login" component={LoginContainer} />
 						<PrivateRoute
 							path="/dashboard"
+							logout={logout}
 							authenticated={authenticated}
 							component={VisualizerContainer}
 						/>
@@ -50,6 +51,7 @@ function mapStateToProps(state) {
 }
 const mapDispatchToProps = {
 	checkSession: userActions.checkSession,
+	logout: userActions.logout,
 };
 
 export default connect(

--- a/src/containers/visualizer.js
+++ b/src/containers/visualizer.js
@@ -15,10 +15,10 @@ class VisualizerContainer extends Component {
 
 const mapStateToProps = state => state;
 
-const mapDispatchToProps = {
+const mapDispatchToProps = (dispatch, props) => ({
 	logout: userActions.logout,
-	...keplerActions,
-};
+	dispatch,
+});
 
 export default connect(
 	mapStateToProps,

--- a/src/containers/visualizer.js
+++ b/src/containers/visualizer.js
@@ -1,22 +1,17 @@
 import React, { Component } from "react";
 import { connect } from "react-redux";
 import Visualizer from "@/components/visualizer";
-import * as keplerActions from "kepler.gl/actions";
 import * as userActions from "@/ducks/user-duck";
 class VisualizerContainer extends Component {
 	render() {
-		return (
-			<div>
-				<Visualizer {...this.props} />
-			</div>
-		);
+		return <Visualizer {...this.props} />;
 	}
 }
 
 const mapStateToProps = state => state;
 
 const mapDispatchToProps = (dispatch, props) => ({
-	logout: userActions.logout,
+	logout: () => dispatch(userActions.logout),
 	dispatch,
 });
 

--- a/src/utils/audio.js
+++ b/src/utils/audio.js
@@ -39,6 +39,13 @@ export class AudioRecorder {
 	};
 }
 
+export function _playBase64Audio(audio) {
+	const speechBlob = base64ToBlob(audio);
+	const speechUrl = URL.createObjectURL(speechBlob);
+	const speechAudio = new Audio(speechUrl);
+	speechAudio.play();
+}
+
 export function base64ToBlob(s) {
 	const byteData = atob(s);
 	const byteNums = new Array(byteData.length);


### PR DESCRIPTION
NOTE: this is a branch off of @jacobpa 's cleanup branch. his should be merged first

Cleaned up the following areas:
 * moved nav bar to render for all private routes instead of being housed directly in visualizer container.
* floating button more concrete (less messy prop-passing now that we know what all it's required to do)
* stray speech-related methods moved to `utils/audio.js`
* refactored all action processing logic into `components/chat/action-processor.js`