### PR TITLE
Don't prompt if only one dataset loaded

### DIFF
--- a/src/components/chat/action-processor.js
+++ b/src/components/chat/action-processor.js
@@ -31,12 +31,12 @@ export default class ActionProcessor {
 		INVALID_FIELD: dataset =>
 			`That doesn't look like a valid field on the ${dataset} dataset.`,
 		SUCCESS_FILTER: "Great, let's get that filter going.",
-		SUCCESS_GENERAL: "Okay, we can do that."
+		SUCCESS_CLEAR: "Okay, let's remove that dataset.",
+		SUCCESS_CHANGE_VIEW: "Alright, changing that for you now!",
 	};
 
 	// static resolution methods
 	static _resolveDataset(datasetName) {
-		console.log(datasetName)
 		var datasetMap = {
 			Earthquake: earthquake,
 			"Sacramento real estate": sacramentoRealEstate,
@@ -192,7 +192,7 @@ export default class ActionProcessor {
 
 	_clearDataset = (dataset) => {
 		this._dispatch(removeDataset(dataset));
-		return [ActionProcessor.RESPONSES.SUCCESS_GENERAL];
+		return [ActionProcessor.RESPONSES.SUCCESS_CLEAR];
 	}
 
 	_loadDataset(datasetName) {
@@ -240,7 +240,7 @@ export default class ActionProcessor {
 				break;
 		}
 
-		return [];
+		return [ActionProcessor.RESPONSES.SUCCESS_CHANGE_VIEW];
 	}
 
 	_executeViewAction(viewAction) {

--- a/src/components/chat/action-processor.js
+++ b/src/components/chat/action-processor.js
@@ -31,10 +31,12 @@ export default class ActionProcessor {
 		INVALID_FIELD: dataset =>
 			`That doesn't look like a valid field on the ${dataset} dataset.`,
 		SUCCESS_FILTER: "Great, let's get that filter going.",
+		SUCCESS_GENERAL: "Okay, we can do that."
 	};
 
 	// static resolution methods
 	static _resolveDataset(datasetName) {
+		console.log(datasetName)
 		var datasetMap = {
 			Earthquake: earthquake,
 			"Sacramento real estate": sacramentoRealEstate,
@@ -190,7 +192,7 @@ export default class ActionProcessor {
 
 	_clearDataset = (dataset) => {
 		this._dispatch(removeDataset(dataset));
-		return [];
+		return [ActionProcessor.RESPONSES.SUCCESS_GENERAL];
 	}
 
 	_loadDataset(datasetName) {

--- a/src/components/chat/chat.test.js
+++ b/src/components/chat/chat.test.js
@@ -8,6 +8,7 @@ import {
   MessageButton,
   MessageInput,
 } from "./index";
+import ActionProcessor from "./action-processor"
 import { sendMessage } from "@/utils/speaq-api";
 
 jest.mock("@/utils/speaq-api"); // Automock speaq-api methods, define implmentation in tests
@@ -17,6 +18,7 @@ describe("<Chat />", () => {
 
   beforeEach(() => {
     wrapper = shallow(<Chat />);
+    const _getAllDatasets = ActionProcessor.prototype._getAllDatasets = jest.fn().mockImplementation(() => []);
   });
 
   it("Should update the state when text is input", () => {

--- a/src/components/chat/index.js
+++ b/src/components/chat/index.js
@@ -144,7 +144,14 @@ export class Chat extends Component {
       ]);
       onInputSpeechSent();
     }
-    const res = await sendMessage(messageContent, messageConfig);
+
+    // get all datasets to send to api
+    const datasets = actionProcessor._getAllDatasets().map(function (element) {
+      return element.id;
+    });
+
+
+    const res = await sendMessage(messageContent, datasets, messageConfig);
 
     // append user input/response as needed
     const dialogue = [];

--- a/src/utils/speaq-api.js
+++ b/src/utils/speaq-api.js
@@ -37,10 +37,13 @@ export async function checkSession() {
 	}
 }
 
-export async function sendMessage(input, config) {
+// datasets is a list of datasets loaded in kepler at the time of sending
+// (before the action is taken)
+export async function sendMessage(input, datasets, config) {
 	try {
 		const res = await axios.post("message/", {
 			input,
+			datasets,
 			config,
 		});
 		return JSON.parse(res.data);


### PR DESCRIPTION
This PR is the client side changes to stop prompting the user for dataset if there is only one loaded dataset. Most of these changes are API and Watson side, this PR only:
- Sends the datasets to the api with each request
- Adds some new response messages. These are helpful to overwrite the prompt for dataset (which is now filled in by the api)

Important - the API side changes must be merged with this! See: https://github.com/speaq-ai/api/pull/12

This closes #28 